### PR TITLE
Fixes an issue with 3rd party libraries that extend the native Array pro...

### DIFF
--- a/jquery.populate.js
+++ b/jquery.populate.js
@@ -224,7 +224,9 @@ jQuery.fn.populate = function(obj, options) {
 
     // update elements
     for(var i in arr) {
-      method(this, i, arr[i]);
+      if (arr.hasOwnProperty(i)) {
+        method(this, i, arr[i]);
+      }
     }
   });
 


### PR DESCRIPTION
...totype.

Some libraries (e. g. Ember.js) modify the native Javascript Array prototype. Additional methods or properties added to the prototype were erroneously being inlcuded in the list of elemets with which to populate the form. This check makes sure that only actual array elements are included in the form.
